### PR TITLE
Ot193 83

### DIFF
--- a/src/main/java/com/alkemy/somosmas/controllers/TestimonialController.java
+++ b/src/main/java/com/alkemy/somosmas/controllers/TestimonialController.java
@@ -2,6 +2,8 @@ package com.alkemy.somosmas.controllers;
 
 import com.alkemy.somosmas.dtos.TestimonialDTO;
 import com.alkemy.somosmas.exceptions.ModelNotFoundException;
+import com.alkemy.somosmas.exceptions.NotAcceptableArgumentException;
+import com.alkemy.somosmas.exceptions.PageEmptyException;
 import com.alkemy.somosmas.services.TestimonialService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -9,7 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/testimonial")
@@ -46,6 +50,25 @@ public class TestimonialController {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
         return ResponseEntity.ok().body(testimonialDTO);
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getAll (@RequestParam int page){
+        Map<String, Object> response = null;
+
+        try {
+            response = this.testimonialService.getAllTestimonialsByPage(page);
+        } catch (NotAcceptableArgumentException e) {
+            response= new HashMap<>();
+            response.put("Error",e.getMessage());
+            return ResponseEntity.badRequest().body(response);
+        } catch (PageEmptyException e) {
+            response= new HashMap<>();
+            response.put("Error",e.getMessage());
+            return ResponseEntity.badRequest().body(response);
+        }
+
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/com/alkemy/somosmas/repositories/TestimonialRepository.java
+++ b/src/main/java/com/alkemy/somosmas/repositories/TestimonialRepository.java
@@ -1,11 +1,12 @@
 package com.alkemy.somosmas.repositories;
 
-import org.springframework.data.repository.CrudRepository;
+
 
 import com.alkemy.somosmas.models.Testimonial;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TestimonialRepository extends CrudRepository<Testimonial, Long> {
+public interface TestimonialRepository extends JpaRepository<Testimonial, Long> {
 
 }

--- a/src/main/java/com/alkemy/somosmas/services/TestimonialService.java
+++ b/src/main/java/com/alkemy/somosmas/services/TestimonialService.java
@@ -2,11 +2,16 @@ package com.alkemy.somosmas.services;
 
 import com.alkemy.somosmas.dtos.TestimonialDTO;
 import com.alkemy.somosmas.exceptions.ModelNotFoundException;
+import com.alkemy.somosmas.exceptions.NotAcceptableArgumentException;
+import com.alkemy.somosmas.exceptions.PageEmptyException;
+
+import java.util.Map;
 
 public interface TestimonialService {
 
     public TestimonialDTO save(TestimonialDTO dto);
     public TestimonialDTO updateTestimonial(TestimonialDTO newTestimonialDTO, Long id) throws ModelNotFoundException;
 	public void delete(Long id) throws ModelNotFoundException;
+    public Map<String, Object> getAllTestimonialsByPage(int pageNo ) throws NotAcceptableArgumentException, PageEmptyException;
 
 }

--- a/src/main/java/com/alkemy/somosmas/services/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/somosmas/services/TestimonialServiceImpl.java
@@ -1,6 +1,11 @@
 package com.alkemy.somosmas.services;
 
+import com.alkemy.somosmas.exceptions.NotAcceptableArgumentException;
+import com.alkemy.somosmas.exceptions.PageEmptyException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.alkemy.somosmas.dtos.TestimonialDTO;
@@ -8,6 +13,11 @@ import com.alkemy.somosmas.exceptions.ModelNotFoundException;
 import com.alkemy.somosmas.models.Testimonial;
 import com.alkemy.somosmas.repositories.TestimonialRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class TestimonialServiceImpl implements TestimonialService {
@@ -51,8 +61,45 @@ public class TestimonialServiceImpl implements TestimonialService {
         }
         this.testimonialRepository.deleteById(id);
     }
-    
 
-    
-    
+    @Override
+    public Map<String, Object> getAllTestimonialsByPage(int pageNo) throws NotAcceptableArgumentException, PageEmptyException {
+
+        if(pageNo<0){
+            throw new NotAcceptableArgumentException("The page number must be positive");
+        }
+        Pageable pageable = PageRequest.of(pageNo,10);
+
+        Page<Testimonial> allTestimonialsPage= testimonialRepository.findAll(pageable);
+
+        if(allTestimonialsPage.isEmpty()){
+            throw new PageEmptyException(pageNo, "testimonials");
+        }
+
+
+        List<Testimonial> testimonialsModel = allTestimonialsPage.getContent();
+
+        List<TestimonialDTO> testimonialDtoReturned = testimonialsModel
+                .stream()
+                .map(i->this.mapper.convertValue(i,TestimonialDTO.class))
+                .collect(Collectors.toList());
+
+
+        Map<String, Object> returnedMap = new HashMap<>();
+        returnedMap.put("Testimonials", testimonialDtoReturned);
+        returnedMap.put("currentPage",allTestimonialsPage.getNumber());
+        returnedMap.put("totalItems",allTestimonialsPage.getTotalElements());
+        returnedMap.put("totalPages",allTestimonialsPage.getTotalPages());
+
+        if (allTestimonialsPage.hasNext()){
+            returnedMap.put("nextPage","localhost:8080/testimonial?page="+(pageNo+1));
+        }
+        if (pageNo!=0){
+            returnedMap.put("previousPage","localhost:8080/testimonial?page="+(pageNo-1));
+        }
+
+        return returnedMap;
+    }
+
+
 }


### PR DESCRIPTION
[OT193-83]


Agregar paginación a Testimonios

COMO usuario
QUIERO visualizar los resultados de Testimonios paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page

*- Evidence

Bad requests:

![image](https://user-images.githubusercontent.com/80424758/170850306-1982d8ac-73c0-4ce9-95be-e34932a25ef7.png)
![image](https://user-images.githubusercontent.com/80424758/170850315-0fdb8625-fa0f-4752-a76f-57972a340cc5.png)

*Succesfull requests*

![image](https://user-images.githubusercontent.com/80424758/170850350-47a58a9f-af47-4cf4-86f3-be545db92625.png)

![image](https://user-images.githubusercontent.com/80424758/170850356-dc230175-4a94-4440-b058-0542d3f91ff7.png)
![image](https://user-images.githubusercontent.com/80424758/170850362-42ddf497-46d5-4a05-9ba6-a951e8bfd22f.png)

